### PR TITLE
Make libdwarf optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,14 @@ DEBUG ?=
 
 # compiler flags
 cc := g++
-cppstd := c++17
-override cppdef +=
+std := c++17
+override cpp +=
 
 cflags := -Wall -Wextra -Wno-unknown-pragmas -fPIE -g
 cflags += $(addprefix -I, $(extlibs_incl))
 cflags += $(addprefix -I, include nrg/include)
-cflags += -std=$(cppstd)
-cflags += $(addprefix -D, $(cppdef))
+cflags += -std=$(std)
+cflags += $(addprefix -D, $(cpp))
 
 ifdef DEBUG
 cflags += -O0
@@ -52,7 +52,7 @@ endif
 ldflags := -pthread -lpugixml -lnrg -lstdc++fs
 ldflags += $(addprefix -L, $(extlibs_dirs) nrg/lib)
 
-ifneq (,$(findstring TEP_USE_LIBDWARF, $(cppdef)))
+ifneq (,$(findstring TEP_USE_LIBDWARF, $(cpp)))
 ldflags += -lbfd -ldwarf
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,13 @@ DEBUG ?=
 # compiler flags
 cc := g++
 cppstd := c++17
+override cppdef +=
 
 cflags := -Wall -Wextra -Wno-unknown-pragmas -fPIE -g
 cflags += $(addprefix -I, $(extlibs_incl))
 cflags += $(addprefix -I, include nrg/include)
 cflags += -std=$(cppstd)
+cflags += $(addprefix -D, $(cppdef))
 
 ifdef DEBUG
 cflags += -O0
@@ -47,8 +49,12 @@ cflags += -O3 -DNDEBUG
 endif
 
 # linker flags
-ldflags := -pthread -lbfd -ldwarf -lpugixml -lnrg -lstdc++fs
+ldflags := -pthread -lpugixml -lnrg -lstdc++fs
 ldflags += $(addprefix -L, $(extlibs_dirs) nrg/lib)
+
+ifneq (,$(findstring TEP_USE_LIBDWARF, $(cppdef)))
+ldflags += -lbfd -ldwarf
+endif
 
 # cmake
 CMAKE := cmake

--- a/src/dbg.cpp
+++ b/src/dbg.cpp
@@ -296,6 +296,31 @@ static dbg_expected<std::vector<parsed_func>> get_functions(const char* target)
     return funcs;
 }
 
+static dbg_expected<bool> has_debug_info(const char* target)
+{
+    assert(target);
+    std::string output = cmmn::concat(file_base, ".dbg");
+    cmmn::expected<file_descriptor, pipe_error> fd = file_descriptor::create(
+        output.c_str(), fd_flags::write, fd_mode::rdwr_all);
+    if (!fd)
+        return dbg_error(dbg_error_code::PIPE_ERROR, std::move(fd.error().msg()));
+
+    piped_commands cmd("objdump", "-h", target);
+    cmd.add("sed", "-nE", "s/.*(debug_info).*/\\1/p");
+
+    if (pipe_error err = cmd.execute(file_descriptor::std_in, fd.value()))
+        return dbg_error(dbg_error_code::PIPE_ERROR, std::move(err.msg()));
+    fd.value().flush();
+
+    std::ifstream ifs(output);
+    if (!ifs)
+        return dbg_error(dbg_error_code::SYSTEM_ERROR,
+            cmmn::concat("Could not open ", output, " for reading"));
+
+    std::string line;
+    std::getline(ifs, line);
+    return !line.empty();
+}
 
 // end helper functions
 
@@ -628,6 +653,18 @@ dbg_info::dbg_info(const char* filename, dbg_error& err) :
     if (err)
         return;
 
+    auto di = has_debug_info(filename);
+    if (!di)
+    {
+        err = std::move(di.error());
+        return;
+    }
+    if (!di.value())
+    {
+        err = { dbg_error_code::DEBUG_SYMBOLS_NOT_FOUND, "No debugging information found" };
+        return;
+    }
+
     FILE* img = fopen(filename, "r");
     if (img == NULL)
     {
@@ -649,7 +686,7 @@ dbg_info::dbg_info(const char* filename, dbg_error& err) :
         err = std::move(error);
 }
 
-bool dbg_info::has_dbg_symbols() const
+bool dbg_info::has_line_info() const
 {
     return !_lines.empty();
 }

--- a/src/dbg.cpp
+++ b/src/dbg.cpp
@@ -1,6 +1,8 @@
 // dbg.cpp
 
+#ifdef TEP_USE_LIBDWARF
 #include <libdwarf/libdwarf.h>
+#endif
 
 #include "dbg.hpp"
 #include "pipe.hpp"
@@ -785,6 +787,8 @@ auto dbg_info::find_lines_impl(T& instance, const char* name)
 }
 
 // TODO: need to rewrite this using newer functions
+#ifdef TEP_USE_LIBDWARF
+
 dbg_error dbg_info::get_line_info(int fd)
 {
     int rv;
@@ -857,6 +861,15 @@ dbg_error dbg_info::get_line_info(int fd)
         return { dbg_error_code::DWARF_ERROR, dwarf_errmsg(dw_err) };
     return dbg_error::success();
 }
+
+#else
+
+dbg_error dbg_info::get_line_info(int)
+{
+    return dbg_error::success();
+}
+
+#endif // TEP_USE_LIBDWARF
 
 dbg_error dbg_info::get_functions(const char* filename)
 {

--- a/src/dbg.hpp
+++ b/src/dbg.hpp
@@ -187,7 +187,7 @@ namespace tep
         dbg_info(const char* filename, dbg_error& err);
 
     public:
-        bool has_dbg_symbols() const;
+        bool has_line_info() const;
         const header_info& header() const;
 
         dbg_expected<const unit_lines*> find_lines(const std::string& name) const;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -297,12 +297,6 @@ tracer_expected<profiling_results> profiler::run()
     log(log_lvl::debug, "[%d] ptrace options successfully set", _tid);
 
     // iterate the sections defined in the config and insert their respective breakpoints
-    if (!_dli.has_dbg_symbols())
-    {
-        log(log_lvl::error, "[%d] no debugging information found", _tid);
-        return tracer_error(tracer_errcode::NO_SYMBOL, "No debugging information found");
-    }
-
     for (const auto& group : _cd.groups())
     {
         for (const auto& sec : group.sections())
@@ -316,6 +310,12 @@ tracer_expected<profiling_results> profiler::run()
             }
             else if (sec.bounds().has_positions())
             {
+                if (!_dli.has_line_info())
+                {
+                    log(log_lvl::error, "[%d] no line information found", _tid);
+                    return tracer_error(tracer_errcode::NO_SYMBOL, "No line information found");
+                }
+
                 auto insert_start = insert_traps_position_start(sec,
                     sec.bounds().start(), entrypoint);
                 if (!insert_start)


### PR DESCRIPTION
Now compiles without `libdwarf` by default, but does not support source-line profiling.
To compile with `libdwarf` set preprocessor macro when compiling, like:
```
make cpp="TEP_USE_LIBDWARF"
```