### PR TITLE
Implement synchronous sampler for short-running workloads

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -37,6 +37,8 @@ namespace tep
         SEC_INVALID_SAMPLES,
         SEC_INVALID_DURATION,
         SEC_LABEL_ALREADY_EXISTS,
+        SEC_BOTH_SHORT_AND_LONG,
+        SEC_INVALID_METHOD_FOR_SHORT,
 
         GROUP_EMPTY,
         GROUP_INVALID_LABEL,
@@ -216,11 +218,22 @@ namespace tep
             uint32_t _executions;
             uint32_t _samples;
             bool _concurrency;
+            bool _isshort;
 
         public:
             template<typename N, typename E, typename B, typename I, typename T>
-            section(N&& nm, E&& extr, T&& tgts, config_data::profiling_method mthd,
-                B&& bnd, I&& intrv, uint32_t execs, uint32_t smp, bool concurrency) :
+            section(
+                N&& nm,
+                E&& extr,
+                T&& tgts,
+                config_data::profiling_method mthd,
+                B&& bnd,
+                I&& intrv,
+                uint32_t execs,
+                uint32_t smp,
+                bool concurrency,
+                bool is_short)
+                :
                 _label(std::forward<N>(nm)),
                 _extra(std::forward<E>(extr)),
                 _targets(std::forward<T>(tgts)),
@@ -229,7 +242,8 @@ namespace tep
                 _interval(std::forward<I>(intrv)),
                 _executions(execs),
                 _samples(smp),
-                _concurrency(concurrency)
+                _concurrency(concurrency),
+                _isshort(is_short)
             {}
 
             const std::string& label() const;
@@ -247,6 +261,7 @@ namespace tep
             bool has_extra() const;
 
             bool allow_concurrency() const;
+            bool is_short() const;
         };
 
         class section_group

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -91,10 +91,20 @@ namespace
         } break;
         case config_data::profiling_method::energy_total:
         {
-            return [reader, interval]()
+            if (section.is_short())
             {
-                return std::make_unique<bounded_ps>(reader, interval);
-            };
+                return [reader]()
+                {
+                    return std::make_unique<short_sampler>(reader);
+                };
+            }
+            else
+            {
+                return [reader, interval]()
+                {
+                    return std::make_unique<bounded_ps>(reader, interval);
+                };
+            }
         } break;
         default:
             assert(false);

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -56,6 +56,24 @@ namespace tep
         const nrgprf::reader* reader() const;
     };
 
+    // short sampler
+
+    class short_sampler : public sampler
+    {
+    private:
+        nrgprf::timed_sample _start;
+        nrgprf::timed_sample _end;
+
+    public:
+        using sampler::sampler;
+
+        sampler_promise run() & override;
+        sampler_expected run() && override;
+
+    private:
+        sampler_expected results() override;
+    };
+
     // sync_sampler
 
     class sync_sampler : public sampler

--- a/src/tracer.hpp
+++ b/src/tracer.hpp
@@ -40,7 +40,7 @@ namespace tep
         std::vector<std::unique_ptr<tracer>> _children;
         const tracer* _parent;
 
-        std::unique_ptr<async_sampler> _sampler;
+        std::unique_ptr<sampler> _sampler;
 
         pid_t _tracee_tgid;
         pid_t _tracee;

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -204,7 +204,7 @@ bool start_trap::allow_concurrency() const
     return _allow_concurrency;
 }
 
-std::unique_ptr<async_sampler> start_trap::create_sampler() const
+std::unique_ptr<sampler> start_trap::create_sampler() const
 {
     return _creator();
 }

--- a/src/trap.hpp
+++ b/src/trap.hpp
@@ -13,9 +13,9 @@
 namespace tep
 {
 
-    class async_sampler;
+    class sampler;
 
-    using sampler_creator = std::function<std::unique_ptr<async_sampler>()>;
+    using sampler_creator = std::function<std::unique_ptr<sampler>()>;
 
     namespace pos
     {
@@ -173,7 +173,7 @@ namespace tep
         {}
 
         bool allow_concurrency() const;
-        std::unique_ptr<async_sampler> create_sampler() const;
+        std::unique_ptr<sampler> create_sampler() const;
     };
 
     class end_trap : public trap


### PR DESCRIPTION
Can annotate the config with `<short/>` or (optionally) `<long/>` tags (default) to indicate whether a section is short- or long-running, respectively.

If a section is short-running, the profiler does not need to create a background thread to do its readings, since this thread is unnecessary if the section has an execution time short enough to avoid issues with counter overflows.

Does not work if `<method></method` is `profile`, so it is only useful for gathering the total energy consumption of a section.