### PR TITLE
Allow to trace a specific executable from command

### DIFF
--- a/src/cmdargs.cpp
+++ b/src/cmdargs.cpp
@@ -2,6 +2,7 @@
 
 #include "cmdargs.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <iostream>
@@ -315,7 +316,23 @@ std::optional<arguments> tep::parse_arguments(int argc, char* const argv[])
     }
 
     if (executable.empty())
+    {
         executable = argv[optind];
+    }
+    else
+    {
+        auto it = std::find_if(argv + optind, argv + argc,
+            [&executable](const char* arg)
+            {
+                return executable == arg;
+            });
+        if (it == argv + argc)
+        {
+            std::cerr << "Invalid --exec: '"
+                << executable << "' not found in executable arguments\n";
+            return std::nullopt;
+        }
+    }
 
     return arguments{
         flags{ bool(idle), cpu_sensors, cpu_sockets, gpu_devices },

--- a/src/cmdargs.hpp
+++ b/src/cmdargs.hpp
@@ -47,6 +47,8 @@ namespace tep
         log_args logargs;
         std::string target;
         char* const* argv;
+
+        bool same_target() const;
     };
 
     std::ostream& operator<<(std::ostream& os, const optional_output_file& f);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,15 @@ int main(int argc, char* argv[])
             return 1;
         }
 
+        if (!args->same_target())
+        {
+            if (auto err = profiler->await_executable(args->target))
+            {
+                std::cerr << err << std::endl;
+                return 1;
+            }
+        }
+
         expected<profiling_results, tracer_error> results = profiler->run();
         if (!results)
         {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -302,6 +302,14 @@ const registered_traps& profiler::traps() const
     return _traps;
 }
 
+
+tracer_error profiler::await_executable(const std::string& name) const
+{
+    (void)name;
+    return tracer_error(tracer_errcode::UNSUPPORTED, "Not implemented");
+}
+
+
 tracer_expected<profiling_results> profiler::run()
 {
     using rettype = tracer_expected<profiling_results>;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -30,6 +30,20 @@ using namespace tep;
 
 namespace
 {
+    std::ostream&
+        operator<<(std::ostream& os, const std::vector<std::string>& vec)
+    {
+        os << "[";
+        for (auto it = std::begin(vec); it != std::end(vec); it++)
+        {
+            os << "\"" << *it << "\"";
+            if (std::distance(it, std::end(vec)) > 1)
+                os << ", ";
+        }
+        os << "]";
+        return os;
+    }
+
     template<typename T>
     std::string to_string(const T& obj)
     {
@@ -376,12 +390,14 @@ tracer_error profiler::await_executable(const std::string& name) const
             if (*filename == name)
             {
                 matched = true;
-                log::logline(log::success, "[%d] found matching execve: %s",
-                    _tid, filename->c_str());
+                log::logline(log::success, "[%d] found matching execve: "
+                    "path=%s args=%s",
+                    _tid, filename->c_str(), to_string(*args).c_str());
             }
             else
-                log::logline(log::debug, "[%d] found execve: %s",
-                    _tid, filename->c_str());
+                log::logline(log::success, "[%d] found execve: "
+                    "path=%s args=%s",
+                    _tid, filename->c_str(), to_string(*args).c_str());
         }
         else if (WIFEXITED(wait_status))
         {

--- a/src/profiler.hpp
+++ b/src/profiler.hpp
@@ -70,6 +70,7 @@ namespace tep
         const config_data& config() const;
         const registered_traps& traps() const;
 
+        tracer_error await_executable(const std::string& name) const;
         nonstd::expected<profiling_results, tracer_error> run();
 
     private:

--- a/src/ptrace_misc.cpp
+++ b/src/ptrace_misc.cpp
@@ -1,0 +1,67 @@
+#include "ptrace_misc.hpp"
+#include "ptrace_wrapper.hpp"
+#include "error.hpp"
+
+#include "nonstd/expected.hpp"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace tep
+{
+    nonstd::expected<std::string, tracer_error>
+        get_string(pid_t pid, uintptr_t address)
+    {
+        using rettype = decltype(ptrace(PTRACE_PEEKTEXT, 0, 0, 0));
+        constexpr auto wordsz = sizeof(rettype);
+
+        std::string str;
+        str.reserve(64);
+        for (auto addr = address; ; addr += wordsz)
+        {
+            int err;
+            auto word = ptrace_wrapper::instance
+                .ptrace(err, PTRACE_PEEKTEXT, pid, addr, 0);
+
+            if (err)
+            {
+                return nonstd::unexpected<tracer_error>(tracer_error(
+                    tracer_errcode::PTRACE_ERROR, "PTRACE_PEEKTEXT"));
+            }
+
+            char buff[wordsz + 1] = {};
+            std::memcpy(buff, &word, wordsz);
+            str.append(buff);
+            if (std::strlen(buff) < wordsz)
+                break;
+        }
+        return str;
+    }
+
+    nonstd::expected<std::vector<std::string>, tracer_error>
+        get_strings(pid_t pid, uintptr_t address)
+    {
+        using rettype = decltype(ptrace(PTRACE_PEEKTEXT, 0, 0, 0));
+        std::vector<std::string> vec;
+        for (auto addr = address; ; addr += sizeof(rettype))
+        {
+            int err;
+            auto word = ptrace_wrapper::instance
+                .ptrace(err, PTRACE_PEEKTEXT, pid, addr, 0);
+            if (err)
+            {
+                return nonstd::unexpected<tracer_error>(tracer_error(
+                    tracer_errcode::PTRACE_ERROR, "PTRACE_PEEKTEXT"));
+            }
+            if (!word)
+                break;
+
+            auto str = get_string(pid, word);
+            if (!str)
+                return nonstd::unexpected<tracer_error>(std::move(str.error()));
+            vec.push_back(*str);
+        }
+        return vec;
+    }
+}

--- a/src/ptrace_misc.hpp
+++ b/src/ptrace_misc.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "error.hpp"
+
+#include <util/expectedfwd.hpp>
+
+#include <string>
+#include <vector>
+
+namespace tep
+{
+    // Retrieve a null-terminated string starting at address <address>
+    // of a tracee with pid <pid>
+    nonstd::expected<std::string, tracer_error>
+        get_string(pid_t pid, uintptr_t address);
+
+    // Retrieve multiple null-terminated strings starting at address <address>
+    // of a tracee with pid <pid>
+    // Useful when retrieving data with the format of the argv array
+    // i.e., null-terminated array of null-terminated strings
+    nonstd::expected<std::vector<std::string>, tracer_error>
+        get_strings(pid_t pid, uintptr_t address);
+}

--- a/src/registers.cpp
+++ b/src/registers.cpp
@@ -144,7 +144,7 @@ syscall_entry cpu_gp_regs::get_syscall_entry() const noexcept
 
 syscall_entry cpu_gp_regs::get_syscall_entry() const noexcept
 {
-    return syscall_data{
+    return syscall_entry{
         _regs.gpr[PT_R0],
         {
             _regs.gpr[PT_R3],

--- a/src/registers.cpp
+++ b/src/registers.cpp
@@ -105,3 +105,56 @@ void cpu_gp_regs::rewind_trap() noexcept
 {}
 
 #endif // __x86_64__ || __i386__
+
+#if defined(__x86_64__)
+
+syscall_entry cpu_gp_regs::get_syscall_entry() const noexcept
+{
+    return syscall_entry{
+        _regs.orig_rax,
+        {
+            _regs.rdi,
+            _regs.rsi,
+            _regs.rdx,
+            _regs.r10,
+            _regs.r8,
+            _regs.r9
+        }
+    };
+}
+
+#elif defined(__i386__)
+
+syscall_entry cpu_gp_regs::get_syscall_entry() const noexcept
+{
+    return syscall_entry{
+        _regs.orig_eax,
+        {
+            _regs.ebx,
+            _regs.ecx,
+            _regs.edx,
+            _regs.esi,
+            _regs.edi,
+            _regs.ebp
+        }
+    };
+}
+
+#elif defined(__powerpc64__)
+
+syscall_entry cpu_gp_regs::get_syscall_entry() const noexcept
+{
+    return syscall_data{
+        _regs.gpr[PT_R0],
+        {
+            _regs.gpr[PT_R3],
+            _regs.gpr[PT_R4],
+            _regs.gpr[PT_R5],
+            _regs.gpr[PT_R6],
+            _regs.gpr[PT_R7],
+            _regs.gpr[PT_R8]
+        }
+    };
+}
+
+#endif // defined(__x86_64__)

--- a/src/registers.hpp
+++ b/src/registers.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "syscall_types.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <sys/user.h>
@@ -39,6 +41,7 @@ namespace tep
         uintptr_t get_ip() const noexcept;
         void set_ip(uintptr_t addr) noexcept;
         void rewind_trap() noexcept;
+        syscall_entry get_syscall_entry() const noexcept;
     };
 
 }

--- a/src/syscall_types.hpp
+++ b/src/syscall_types.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace tep
+{
+    struct syscall_entry
+    {
+        static constexpr auto max_args = 6UL;
+
+        uint64_t number;
+        std::array<uint64_t, max_args> args;
+    };
+}

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -58,6 +58,6 @@ void tep::run_target(char* const argv[])
         return;
     log::flush();
     // execute target executable
-    if (execv(argv[0], argv) == -1)
+    if (execvp(argv[0], argv) == -1)
         log::logline(log::error, "[%d] execv error: %s", pid, strerror(errno));
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -127,17 +127,21 @@ bool tep::is_syscall_trap(int wait_status)
         WSTOPSIG(wait_status) == (SIGTRAP | 0x80);
 }
 
-int tep::get_ptrace_opts(bool trace_children)
+int tep::get_ptrace_exitkill()
 {
     // TODO: find a way to always set option PTRACE_O_EXITKILL
     // should be present since Linux 3.8 but not always defined in ptrace headers
 #if !defined(PTRACE_O_EXITKILL)
 #define PTRACE_O_EXITKILL (1 << 20)
 #endif
+    return PTRACE_O_EXITKILL;
+}
 
+int tep::get_ptrace_opts(bool trace_children)
+{
     int opts = 0;
     // kill the tracee when the profiler errors
-    opts = PTRACE_O_EXITKILL;
+    opts = get_ptrace_exitkill();
     if (trace_children)
     {
         // trace threads being spawned using clone()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -121,6 +121,12 @@ bool tep::is_breakpoint_trap(int wait_status)
         (WSTOPSIG(wait_status) == SIGTRAP);
 }
 
+bool tep::is_syscall_trap(int wait_status)
+{
+    return WIFSTOPPED(wait_status) &&
+        WSTOPSIG(wait_status) == (SIGTRAP | 0x80);
+}
+
 int tep::get_ptrace_opts(bool trace_children)
 {
     // TODO: find a way to always set option PTRACE_O_EXITKILL

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -32,5 +32,6 @@ namespace tep
 
     const char* sig_str(int signal);
 
+    int get_ptrace_exitkill();
     int get_ptrace_opts(bool trace_children);
 }

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -28,6 +28,7 @@ namespace tep
     bool is_child_event(int wait_status);
     bool is_exit_event(int wait_status);
     bool is_breakpoint_trap(int wait_status);
+    bool is_syscall_trap(int wait_status);
 
     const char* sig_str(int signal);
 


### PR DESCRIPTION
Useful when the command consists of a wrapper program which, in turn, runs the executable to profile