### PR TITLE
Implement helper methods in NRG

### DIFF
--- a/nrg/include/nrg/detail/hybrid_reader_tp.inl
+++ b/nrg/include/nrg/detail/hybrid_reader_tp.inl
@@ -1,6 +1,9 @@
 #include <nrg/hybrid_reader_tp.hpp>
 
 #include <nrg/error.hpp>
+#include <nrg/sample.hpp>
+
+#include <nonstd/expected.hpp>
 
 namespace nrgprf
 {
@@ -73,6 +76,23 @@ namespace nrgprf
     {
         return error(error_code::NOT_IMPL,
             "Reading specific events not supported");
+    }
+
+    template<typename... Ts>
+    result<sample> hybrid_reader_tp<Ts...>::read() const
+    {
+        sample s;
+        if (error err = read(s))
+            return result<sample>{ nonstd::unexpect, std::move(err) };
+        return s;
+    }
+
+    template<typename... Ts>
+    result<sample> hybrid_reader_tp<Ts...>::read(uint8_t) const
+    {
+        return result<sample>{ nonstd::unexpect,
+            error_code::NOT_IMPL,
+            "Reading specific events not supported" };
     }
 
     template<typename... Ts>

--- a/nrg/include/nrg/hybrid_reader.hpp
+++ b/nrg/include/nrg/hybrid_reader.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <nrg/reader.hpp>
+#include <nrg/types.hpp>
 #include <nrg/detail/all_reader_ptrs.hpp>
 
 #include <vector>
@@ -27,6 +28,8 @@ namespace nrgprf
 
         error read(sample&) const override;
         error read(sample&, uint8_t ev_idx) const override;
+        result<sample> read() const override;
+        result<sample> read(uint8_t) const override;
         size_t num_events() const override;
     };
 

--- a/nrg/include/nrg/hybrid_reader_tp.hpp
+++ b/nrg/include/nrg/hybrid_reader_tp.hpp
@@ -55,6 +55,8 @@ namespace nrgprf
 
         error read(sample&) const override;
         error read(sample&, uint8_t) const override;
+        result<sample> read() const override;
+        result<sample> read(uint8_t) const override;
         size_t num_events() const override;
     };
 

--- a/nrg/include/nrg/reader.hpp
+++ b/nrg/include/nrg/reader.hpp
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <nrg/types.hpp>
+
 namespace nrgprf
 {
 
@@ -19,6 +21,8 @@ namespace nrgprf
     public:
         virtual error read(sample& s) const = 0;
         virtual error read(sample& s, uint8_t ev_idx) const = 0;
+        virtual result<sample> read() const = 0;
+        virtual result<sample> read(uint8_t ev_idx) const = 0;
         virtual size_t num_events() const = 0;
     };
 

--- a/nrg/include/nrg/reader_gpu.hpp
+++ b/nrg/include/nrg/reader_gpu.hpp
@@ -54,6 +54,8 @@ namespace nrgprf
 
         error read(sample& s) const override;
         error read(sample& s, uint8_t ev_idx) const override;
+        result<sample> read() const override;
+        result<sample> read(uint8_t) const override;
         size_t num_events() const override;
 
         int8_t event_idx(readings_type::type rt, uint8_t device) const;

--- a/nrg/include/nrg/reader_gpu.hpp
+++ b/nrg/include/nrg/reader_gpu.hpp
@@ -26,7 +26,19 @@ namespace nrgprf
         static result<readings_type::type> support(device_mask);
         static result<readings_type::type> support();
 
-    public:
+        static result<reader_gpu> create(
+            readings_type::type,
+            device_mask,
+            std::ostream & = std::cout);
+        static result<reader_gpu> create(
+            readings_type::type,
+            std::ostream & = std::cout);
+        static result<reader_gpu> create(
+            device_mask,
+            std::ostream & = std::cout);
+        static result<reader_gpu> create(
+            std::ostream & = std::cout);
+
         explicit reader_gpu(readings_type::type, device_mask, error&, std::ostream & = std::cout);
         explicit reader_gpu(readings_type::type, error&, std::ostream & = std::cout);
         explicit reader_gpu(device_mask, error&, std::ostream & = std::cout);

--- a/nrg/include/nrg/reader_rapl.hpp
+++ b/nrg/include/nrg/reader_rapl.hpp
@@ -23,6 +23,19 @@ namespace nrgprf
         std::unique_ptr<impl> _impl;
 
     public:
+        static result<reader_rapl> create(
+            location_mask,
+            socket_mask,
+            std::ostream & = std::cout);
+        static result<reader_rapl> create(
+            location_mask,
+            std::ostream & = std::cout);
+        static result<reader_rapl> create(
+            socket_mask,
+            std::ostream & = std::cout);
+        static result<reader_rapl> create(
+            std::ostream & = std::cout);
+
         explicit reader_rapl(location_mask, socket_mask, error&, std::ostream & = std::cout);
         explicit reader_rapl(location_mask, error&, std::ostream & = std::cout);
         explicit reader_rapl(socket_mask, error&, std::ostream & = std::cout);

--- a/nrg/include/nrg/reader_rapl.hpp
+++ b/nrg/include/nrg/reader_rapl.hpp
@@ -51,6 +51,8 @@ namespace nrgprf
 
         error read(sample& s) const override;
         error read(sample& s, uint8_t ev_idx) const override;
+        result<sample> read() const override;
+        result<sample> read(uint8_t) const override;
         size_t num_events() const override;
 
         template<typename Tag>

--- a/nrg/src/create_reader.hpp
+++ b/nrg/src/create_reader.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "visibility.hpp"
+
+#include <nrg/error.hpp>
+#include <nonstd/expected.hpp>
+
+#include <utility>
+
+namespace nrgprf
+{
+    template<typename R, typename... Args>
+    NRG_LOCAL result<R> create_reader_impl(std::ostream& os, Args... args)
+    {
+        error err = error::success();
+        R reader(args..., err, os);
+        if (err)
+            return result<R>{ nonstd::unexpect, std::move(err) };
+        return reader;
+    }
+}

--- a/nrg/src/hybrid_reader.cpp
+++ b/nrg/src/hybrid_reader.cpp
@@ -1,8 +1,10 @@
 // hybrid_reader.cpp
 
 #include <nrg/hybrid_reader.hpp>
-
 #include <nrg/error.hpp>
+#include <nrg/sample.hpp>
+
+#include <nonstd/expected.hpp>
 
 #include <cassert>
 
@@ -28,6 +30,21 @@ error hybrid_reader::read(sample& s) const
 error hybrid_reader::read(sample&, uint8_t) const
 {
     return error(error_code::NOT_IMPL, "Reading specific events not supported");
+}
+
+result<sample> hybrid_reader::read() const
+{
+    sample s;
+    if (error err = read(s))
+        return result<sample>{ nonstd::unexpect, std::move(err) };
+    return s;
+}
+
+result<sample> hybrid_reader::read(uint8_t) const
+{
+    return result<sample>{ nonstd::unexpect,
+        error_code::NOT_IMPL,
+        "Reading specific events not supported" };
 }
 
 size_t hybrid_reader::num_events() const

--- a/nrg/src/reader_gpu.cpp
+++ b/nrg/src/reader_gpu.cpp
@@ -5,6 +5,7 @@
 #include "create_reader.hpp"
 
 #include <nrg/reader_gpu.hpp>
+#include <nrg/sample.hpp>
 
 #include <nonstd/expected.hpp>
 
@@ -84,6 +85,22 @@ error reader_gpu::read(sample & s) const
 error reader_gpu::read(sample & s, uint8_t ev_idx) const
 {
     return pimpl()->read(s, ev_idx);
+}
+
+result<sample> reader_gpu::read() const
+{
+    sample s;
+    if (error err = read(s))
+        return result<sample>{ nonstd::unexpect, std::move(err) };
+    return s;
+}
+
+result<sample> reader_gpu::read(uint8_t idx) const
+{
+    sample s;
+    if (error err = read(s, idx))
+        return result<sample>{ nonstd::unexpect, std::move(err) };
+    return s;
 }
 
 int8_t reader_gpu::event_idx(readings_type::type rt, uint8_t device) const

--- a/nrg/src/reader_gpu.cpp
+++ b/nrg/src/reader_gpu.cpp
@@ -2,6 +2,7 @@
 
 #include "visibility.hpp"
 #include "reader_gpu.hpp"
+#include "create_reader.hpp"
 
 #include <nrg/reader_gpu.hpp>
 
@@ -13,6 +14,27 @@ struct NRG_LOCAL reader_gpu::impl : reader_gpu_impl
 {
     using reader_gpu_impl::reader_gpu_impl;
 };
+
+result<reader_gpu> reader_gpu::create(
+    readings_type::type rt, device_mask dm, std::ostream& os)
+{
+    return create_reader_impl<reader_gpu>(os, rt, dm);
+}
+
+result<reader_gpu> reader_gpu::create(readings_type::type rt, std::ostream& os)
+{
+    return create_reader_impl<reader_gpu>(os, rt);
+}
+
+result<reader_gpu> reader_gpu::create(device_mask dm, std::ostream& os)
+{
+    return create_reader_impl<reader_gpu>(os, dm);
+}
+
+result<reader_gpu> reader_gpu::create(std::ostream& os)
+{
+    return create_reader_impl<reader_gpu>(os);
+}
 
 result<readings_type::type> reader_gpu::support(device_mask devmask)
 {

--- a/nrg/src/reader_rapl.cpp
+++ b/nrg/src/reader_rapl.cpp
@@ -5,6 +5,7 @@
 #include "create_reader.hpp"
 
 #include <nrg/reader_rapl.hpp>
+#include <nrg/sample.hpp>
 
 #include <nonstd/expected.hpp>
 
@@ -76,6 +77,22 @@ error reader_rapl::read(sample & s) const
 error reader_rapl::read(sample & s, uint8_t idx) const
 {
     return pimpl()->read(s, idx);
+}
+
+result<sample> reader_rapl::read() const
+{
+    sample s;
+    if (error err = read(s))
+        return result<sample>{ nonstd::unexpect, std::move(err) };
+    return s;
+}
+
+result<sample> reader_rapl::read(uint8_t idx) const
+{
+    sample s;
+    if (error err = read(s, idx))
+        return result<sample>{ nonstd::unexpect, std::move(err) };
+    return s;
 }
 
 size_t reader_rapl::num_events() const

--- a/nrg/src/reader_rapl.cpp
+++ b/nrg/src/reader_rapl.cpp
@@ -2,6 +2,7 @@
 
 #include "reader_cpu.hpp"
 #include "visibility.hpp"
+#include "create_reader.hpp"
 
 #include <nrg/reader_rapl.hpp>
 
@@ -15,6 +16,27 @@ struct NRG_LOCAL reader_rapl::impl : reader_impl
 {
     using reader_impl::reader_impl;
 };
+
+result<reader_rapl> reader_rapl::create(
+    location_mask lm, socket_mask sm, std::ostream& os)
+{
+    return create_reader_impl<reader_rapl>(os, lm, sm);
+}
+
+result<reader_rapl> reader_rapl::create(location_mask lm, std::ostream& os)
+{
+    return create_reader_impl<reader_rapl>(os, lm);
+}
+
+result<reader_rapl> reader_rapl::create(socket_mask sm, std::ostream& os)
+{
+    return create_reader_impl<reader_rapl>(os, sm);
+}
+
+result<reader_rapl> reader_rapl::create(std::ostream& os)
+{
+    return create_reader_impl<reader_rapl>(os);
+}
 
 reader_rapl::reader_rapl(location_mask dmask, socket_mask skt_mask, error& ec, std::ostream& os) :
     _impl(std::make_unique<reader_rapl::impl>(dmask, skt_mask, ec, os))


### PR DESCRIPTION
Use `expected<T>` instead of an output parameter