### PR TITLE
Function profiling return address fixes & changes

### DIFF
--- a/src/registers.cpp
+++ b/src/registers.cpp
@@ -126,8 +126,9 @@ cpu_gp_regs::get_return_address() const noexcept {
   using unexpected = nonstd::expected<uintptr_t, tracer_error>::unexpected_type;
   ptrace_wrapper &pw = ptrace_wrapper::instance;
   int error;
-  long ret_addr = pw.ptrace(error, PTRACE_PEEKDATA, _pid,
-                            get_stack_pointer() + sizeof(long), 0);
+  // read a word of 8 bytes in [sp, sp+8)
+  long ret_addr =
+      pw.ptrace(error, PTRACE_PEEKDATA, _pid, get_stack_pointer(), 0);
   if (error)
     return unexpected{get_syserror(error, tracer_errcode::PTRACE_ERROR, _pid,
                                    "get_return_address: PTRACE_PEEKDATA")};

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -214,6 +214,32 @@ tracer_error tracer::handle_breakpoint(cpu_gp_regs &regs, const trap &t) const {
   return tracer_error::success();
 }
 
+tracer_expected<std::pair<trap_context, long>>
+tracer::handle_function_entry(const cpu_gp_regs &regs) const {
+  auto get_func_return_ctx =
+      [](const cpu_gp_regs &regs) -> tracer_expected<trap_context> {
+    using unexpected = tracer_expected<trap_context>::unexpected_type;
+    auto ret_addr = regs.get_return_address();
+    if (!ret_addr)
+      return unexpected{std::move(ret_addr).error()};
+    return trap_context{function_return{*ret_addr, nullptr}};
+  };
+
+  using unexpected =
+      tracer_expected<std::pair<trap_context, long>>::unexpected_type;
+  long origword = 0;
+  auto func_end_ctx = get_func_return_ctx(regs);
+  if (!func_end_ctx)
+    return unexpected{std::move(func_end_ctx).error()};
+  log::logline(log::debug, "function return address @ 0x%" PRIxPTR,
+               func_end_ctx->addr());
+  auto res = insert_trap(_tracee, func_end_ctx->addr());
+  if (!res)
+    return unexpected{std::move(res).error()};
+  origword = *res;
+  return std::pair{*std::move(func_end_ctx), origword};
+}
+
 tracer_error tracer::trace(const registered_traps *traps) {
   assert(traps != nullptr);
 
@@ -295,30 +321,12 @@ tracer_error tracer::trace(const registered_traps *traps) {
         log::logline(log::info,
                      "[%d] concurrency allowed; not stopping tracees", tid);
 
-      auto get_func_return_ctx = [&](const trap_context &x)
-          -> tracer_expected<std::optional<trap_context>> {
-        using unexpected = tracer_expected<trap_context>::unexpected_type;
-        if (!x.is_function_call())
-          return std::nullopt;
-        auto ret_addr = regs.get_return_address();
-        if (!ret_addr)
-          return unexpected{std::move(ret_addr).error()};
-        return trap_context{function_return{*ret_addr, nullptr}};
-      };
-
-      long origword = 0;
-      auto func_end_ctx = get_func_return_ctx(strap->context());
-      if (!func_end_ctx)
-        return std::move(func_end_ctx).error();
-      if (*func_end_ctx) {
-        log::logline(
-            log::debug,
-            "[%d] function return address @ 0x%" PRIxPTR " (0x%" PRIxPTR ")",
-            tid, (*func_end_ctx)->addr(), (*func_end_ctx)->addr() - entrypoint);
-        auto res = insert_trap(_tracee, func_end_ctx.value().value().addr());
+      std::optional<std::pair<trap_context, long>> func_return;
+      if (strap->context().is_function_call()) {
+        auto res = handle_function_entry(regs);
         if (!res)
           return std::move(res).error();
-        origword = *res;
+        func_return = *std::move(res);
       }
 
       if (auto error = handle_breakpoint(regs, *strap))
@@ -344,14 +352,14 @@ tracer_error tracer::trace(const registered_traps *traps) {
 
         const trap_context *end_ctx = nullptr;
         regs.rewind_trap();
-        if (*func_end_ctx) {
-          auto addr = func_end_ctx.value().value().addr();
-          if (regs.get_ip() != addr) {
+        if (func_return) {
+          auto [ctx, origword] = *func_return;
+          if (regs.get_ip() != ctx.addr()) {
             log::logline(log::error,
                          "[%d] reached trap @ 0x%" PRIxPTR " (0x%" PRIxPTR
                          ") which is not %s's return @ 0x%" PRIxPTR,
                          tid, regs.get_ip(), regs.get_ip() - entrypoint,
-                         to_string(strap->context()).c_str(), addr);
+                         to_string(strap->context()).c_str(), ctx.addr());
             const start_trap *strap = traps->find(start_addr{regs.get_ip()});
             if (strap)
               log::logline(log::error, "[%d] reached trap of %s", tid,
@@ -361,15 +369,16 @@ tracer_error tracer::trace(const registered_traps *traps) {
           }
           if (auto error = regs.setregs())
             return error;
-          if (pw.ptrace(errnum, PTRACE_POKEDATA, _tracee, addr, origword) == -1)
+          if (pw.ptrace(errnum, PTRACE_POKEDATA, _tracee, ctx.addr(),
+                        origword) == -1)
             return get_syserror(errnum, tracer_errcode::PTRACE_ERROR, tid,
                                 "PTRACE_POKEDATA");
           log::logline(
               log::debug,
               "[%d] reset original word at function return @ 0x%" PRIxPTR
               " (0x%lx -> 0x%lx)",
-              tid, addr, set_trap(origword), origword);
-          end_ctx = &**func_end_ctx;
+              tid, ctx.addr(), set_trap(origword), origword);
+          end_ctx = &(func_return->first);
         } else {
           end_addr end_bp_addr = regs.get_ip();
           const end_trap *etrap = traps->find(end_bp_addr, start_bp_addr);

--- a/src/tracer.hpp
+++ b/src/tracer.hpp
@@ -73,6 +73,9 @@ private:
   tracer_error reset_trap(const trap &, uintptr_t addr) const;
   tracer_error handle_breakpoint(cpu_gp_regs &regs, const trap &) const;
   tracer_error trace(const registered_traps *traps);
+
+  tracer_expected<std::pair<trap_context, long>>
+  handle_function_entry(const cpu_gp_regs &) const;
 };
 
 // operator overloads


### PR DESCRIPTION
Fix reading return address from stack and move query to before handling the breakpoint.
Add helper method to handle function entry