### PR TITLE
Signal tweaks in tracer

### DIFF
--- a/src/ptrace_restarter.hpp
+++ b/src/ptrace_restarter.hpp
@@ -13,7 +13,7 @@ public:
   ptrace_restarter(pid_t tid, pid_t tracee) noexcept;
   ~ptrace_restarter() noexcept;
 
-  tracer_error cont() noexcept;
+  tracer_error resume(int signo = 0) noexcept;
 
   ptrace_restarter(ptrace_restarter &&other) noexcept;
   ptrace_restarter &operator=(ptrace_restarter &&other) noexcept;


### PR DESCRIPTION
- change isolated mode signal from `SIGSTOP` to `SIGUSR1`
- actually inject signals now, as expected
  - isolated mode still does not inject signals
- support signals during section execution