### PR TITLE
Provide ASLR switch at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,6 @@ Other Make variables which can be overriden:
 * `system_clock` - use the system's clock instead of a steady clock for
   timestamps; use when an absolute, real time is necessary
 
-Additionally, some options are provided as preprocessor definitions.
-Enable them by running `make` with the `cpp` argument:
-
-```shell
-make cpp="MY_MACRO_DEFINITION"
-```
-
-Supported preprocessor definitions are:
-
-* `NO_ASLR` - disable ASLR for the target executable (enabled by default)
-
 The building procedure will generate an executable `profiler` in `bin`.
 
 ## Examples
@@ -218,6 +207,7 @@ options:
   --cpu-sockets {MASK,all}      mask of CPU sockets to profile in hexadecimal, overwrites config value (default: use value in config)
   --gpu-devices {MASK,all}      mask of GPU devices to profile in hexadecimal, overwrites config value (default: use value in config)
   --exec <path>                 evaluate executable <path> instead of <executable>; used when <executable> is some wrapper program which launches <path> (default: <executable>)
+  --enable-randomization        enable Address Space Layout Randomization (ASLR) for the target application
 ```
 
 Example of running the profiler for socket 0 (`--cpu-sockets`),

--- a/src/cmdargs.cpp
+++ b/src/cmdargs.cpp
@@ -118,58 +118,65 @@ void print_usage(const char *profiler_name) {
 
   std::cout << "options:\n";
 
-  std::cout << parameter{"-h, --help"} << "print this message and exit"
-            << "\n";
+  std::cout << parameter{"-h, --help"}
+            << "print this message and exit"
+               "\n";
 
   std::cout << parameter{"-c, --config <file>"}
             << "(optional) read from configuration file <file>; "
-            << "if <file> is 'stdin' then stdin is used (default: stdin)"
-            << "\n";
+               "if <file> is 'stdin' then stdin is used (default: stdin)"
+               "\n";
 
   std::cout << parameter{"-o, --output <file>"}
             << "(optional) write profiling results to <file>; "
-            << "if <file> is 'stdout' then stdout is used (default: stdout)"
-            << "\n";
+               "if <file> is 'stdout' then stdout is used (default: stdout)"
+               "\n";
 
   std::cout << parameter{"-q, --quiet"}
             << "suppress log messages except errors to stderr (default: off)"
-            << "\n";
+               "\n";
 
   std::cout << parameter{"-l, --log <file>"}
             << "(optional) write log to <file> (default: stdout)"
-            << "\n";
+               "\n";
 
   std::cout << parameter{"--debug-dump <file>"}
             << "(optional) dump gathered debug info in JSON format to <file>"
-            << "\n";
+               "\n";
 
-  std::cout << parameter{"--idle"} << "gather idle readings at startup"
-            << "\n";
+  std::cout << parameter{"--idle"}
+            << "gather idle readings at startup"
+               "\n";
 
   std::cout << parameter{"--no-idle"}
             << "do not gather idle readings at startup (default)"
-            << "\n";
+               "\n";
 
   std::cout << parameter{"--cpu-sensors {MASK,all}"}
             << "mask of CPU sensors to read in hexadecimal, "
-            << "overwrites config value (default: use value in config)"
-            << "\n";
+               "overwrites config value (default: use value in config)"
+               "\n";
 
   std::cout << parameter{"--cpu-sockets {MASK,all}"}
             << "mask of CPU sockets to profile in hexadecimal, "
-            << "overwrites config value (default: use value in config)"
-            << "\n";
+               "overwrites config value (default: use value in config)"
+               "\n";
 
   std::cout << parameter{"--gpu-devices {MASK,all}"}
             << "mask of GPU devices to profile in hexadecimal, "
-            << "overwrites config value (default: use value in config)"
-            << "\n";
+               "overwrites config value (default: use value in config)"
+               "\n";
 
   std::cout << parameter{"--exec <path>"}
             << "evaluate executable <path> instead of <executable>; "
-            << "used when <executable> is some wrapper program "
-            << "which launches <path> (default: <executable>)"
-            << "\n";
+               "used when <executable> is some wrapper program "
+               "which launches <path> (default: <executable>)"
+               "\n";
+
+  std::cout << parameter{"--enable-randomization"}
+            << "Enable Address Space Layout Randomization (ASLR) for the target"
+               " application"
+               "\n";
 
   std::cout.flush();
   std::cout.flags(flags);
@@ -180,6 +187,7 @@ std::optional<arguments> tep::parse_arguments(int argc, char *const argv[]) {
   int option_index = 0;
   int idle = 0;
   bool quiet = false;
+  bool randomize = false;
   std::string output;
   std::string config;
   std::string logpath;
@@ -203,6 +211,7 @@ std::optional<arguments> tep::parse_arguments(int argc, char *const argv[]) {
       {gpu_devices_str.data(), required_argument, nullptr, 0x102},
       {"exec", required_argument, nullptr, 0x103},
       {"debug-dump", required_argument, nullptr, 0x104},
+      {"enable-randomization", no_argument, nullptr, 0x105},
       {nullptr, 0, nullptr, 0}};
 
   while ((c = getopt_long(argc, argv, "hqc:o:l:", long_options,
@@ -247,6 +256,9 @@ std::optional<arguments> tep::parse_arguments(int argc, char *const argv[]) {
                   << " cannot be empty\n";
         return std::nullopt;
       }
+      break;
+    case 0x105:
+      randomize = true;
       break;
     case 'c':
       config = optarg;
@@ -320,6 +332,7 @@ std::optional<arguments> tep::parse_arguments(int argc, char *const argv[]) {
   }
 
   return arguments{flags{bool(idle), cpu_sensors, cpu_sockets, gpu_devices},
+                   randomize,
                    std::move(config),
                    std::move(of),
                    std::move(dd),

--- a/src/cmdargs.cpp
+++ b/src/cmdargs.cpp
@@ -174,7 +174,7 @@ void print_usage(const char *profiler_name) {
                "\n";
 
   std::cout << parameter{"--enable-randomization"}
-            << "Enable Address Space Layout Randomization (ASLR) for the target"
+            << "enable Address Space Layout Randomization (ASLR) for the target"
                " application"
                "\n";
 

--- a/src/cmdargs.hpp
+++ b/src/cmdargs.hpp
@@ -37,6 +37,7 @@ struct log_args {
 
 struct arguments {
   flags profiler_flags;
+  bool enable_randomization;
   optional_input_file config;
   optional_output_file output;
   std::ofstream debug_dump;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,9 +51,12 @@ int main(int argc, char *argv[]) {
     if (args->debug_dump)
       args->debug_dump << dbg::debug_dump{oinfo};
 
+    auto callback = [](ptrace_wrapper::callback_args_t x) {
+      run_target(x.randomize, x.argv);
+    };
     int errnum;
-    pid_t child_pid =
-        ptrace_wrapper::instance.fork(errnum, &run_target, args->argv);
+    pid_t child_pid = ptrace_wrapper::instance.fork(
+        errnum, callback, {args->enable_randomization, args->argv});
     if (child_pid > 0) {
       profiler prof(child_pid, args->profiler_flags, oinfo, config);
       if (!args->same_target()) {

--- a/src/ptrace_wrapper.hpp
+++ b/src/ptrace_wrapper.hpp
@@ -14,23 +14,32 @@ class ptrace_wrapper {
 public:
   static ptrace_wrapper instance;
 
+  struct callback_args_t {
+    bool randomize;
+    char *const *argv;
+  };
+
+  using callback_t = void(callback_args_t);
+
 private:
-  enum class request;
+  using ptrace_req = __ptrace_request;
+
+  enum class request : uint32_t;
 
   struct request_data {
     request req;
     union {
       struct {
         long result;
-        __ptrace_request req;
+        ptrace_req req;
         pid_t pid;
         void *addr;
         void *data;
       } ptrace;
       struct {
         pid_t result;
-        void (*callback)(char *const[]);
-        char *const *arg;
+        callback_t *callback;
+        callback_args_t args;
       } fork;
     };
     int error;
@@ -48,9 +57,8 @@ private:
   ~ptrace_wrapper() noexcept;
 
 public:
-  long ptrace(int &error, __ptrace_request req, pid_t pid, ...) noexcept;
-  pid_t fork(int &error, void (*callback)(char *const[]),
-             char *const *arg) noexcept;
+  long ptrace(int &error, ptrace_req req, pid_t pid, ...) noexcept;
+  pid_t fork(int &error, callback_t *callback, callback_args_t args) noexcept;
 };
 
 } // namespace tep

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -4,6 +4,6 @@
 
 namespace tep {
 
-void run_target(char *const argv[]);
+void run_target(bool aslr_randomization, char *const argv[]);
 
 }


### PR DESCRIPTION
New argument `--enable-randomization` provided.
ASLR off by default.
Only applicable when target is a PIE.